### PR TITLE
Fix running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Tesseract OCR を実行して、検出したテキストと注釈付き画像を
 
    さらに Tesseract 本体もシステムにインストールしておく必要があります。
 
-2. `backend` ディレクトリから API サーバーを起動します:
+2. `backend` ディレクトリから API サーバーを起動します。以下のどちらかの方法を使います:
 
    ```bash
    uvicorn main:app --reload
+   # または
+   python main.py
    ```
 
 3. ブラウザで `frontend/index.html` を開きます。画像を選択した後、

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,3 +30,7 @@ async def ocr(file: UploadFile = File(...)):
 @app.get("/annotated/{image_name}")
 def get_annotated(image_name: str):
     return FileResponse(f"{ANNOTATED_DIR}/{image_name}")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- allow running API server directly with `python main.py`
- update readme with alternate command

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856d9c602d08328823c567d2097406e